### PR TITLE
Fix wiki link

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -71,7 +71,7 @@ The (un)conference about Free Software and Open Data for mobility and public tra
 Connect with open source and open data communities from
 Transitous, MOTIS, OpenStreetMap, OpenTripPlanner, and many more!
 
-**More information for conference attendees can be found on our [wiki](github.com/public-transport/open-transport-community-conference/wiki)**
+**More information for conference attendees can be found on our [wiki](https://github.com/public-transport/open-transport-community-conference/wiki)**
 
 ## Who are we?
 


### PR DESCRIPTION
This needs to be an absolute URL to actually work.